### PR TITLE
Fix bootstrapper manifest format in UpdateCoordinator

### DIFF
--- a/MidsReborn/UI/Forms/UpdateSystem/UpdateCoordinator.cs
+++ b/MidsReborn/UI/Forms/UpdateSystem/UpdateCoordinator.cs
@@ -98,7 +98,18 @@ namespace Mids_Reborn.UI.Forms.UpdateSystem
                 Converters = { new JsonStringEnumConverter() }
             };
 
-            File.WriteAllText(tempPath, JsonSerializer.Serialize(entries, options));
+            // Wrap entries in a Manifest-shaped object so MRBBootstrap can
+            // deserialize the file as MRB_Boostrap.Models.Manifest.
+            // Previously this serialized the bare List<ManifestEntryDto>,
+            // producing a JSON array that the bootstrapper could not parse.
+            var manifest = new
+            {
+                ManifestVersion = "3.0",
+                Updates = entries,
+                LastUpdated = DateTime.UtcNow.ToString("MM/dd/yyyy HH:mm:ss")
+            };
+
+            File.WriteAllText(tempPath, JsonSerializer.Serialize(manifest, options));
             return tempPath;
         }
 


### PR DESCRIPTION
## Summary

- `WriteTemporaryManifest` was serializing `List<ManifestEntryDto>` directly, producing a bare JSON array (`[{...}]`)
- `MRBBootstrap` deserializes this file as `MRB_Boostrap.Models.Manifest`, which expects a JSON object (`{"ManifestVersion": "...", "Updates": [...], "LastUpdated": "..."}`)
- This mismatch causes a `JsonSerializationException` in the bootstrapper, **preventing all updates from being applied**

## Fix

Wrap the entries list in an anonymous object matching the `Manifest` schema before serializing to the temp file.

## How to reproduce

1. Launch Mids Reborn with an update available
2. Accept the update prompt
3. Bootstrapper launches but fails with: `Cannot deserialize the current JSON array into type 'MRB_Boostrap.Models.Manifest'`

## Test plan

- [ ] Trigger an update check with a pending app or DB update
- [ ] Verify the temp manifest JSON is a valid object (not a bare array)
- [ ] Verify MRBBootstrap successfully parses the manifest and applies the update