### PR TITLE
Fix culture-sensitive Maths.mhd parsing

### DIFF
--- a/MidsReborn/Core/DatabaseAPI.cs
+++ b/MidsReborn/Core/DatabaseAPI.cs
@@ -2457,7 +2457,7 @@ namespace Mids_Reborn.Core
                     var strArray = FileIO.IOGrab(streamReader);
                     for (var index2 = 0; index2 < 4; ++index2)
                     {
-                        var ret = float.TryParse(strArray[index2 + 1], out Database.MultED[index2][index1]);
+                        var ret = TryParseMathValue(strArray[index2 + 1], out Database.MultED[index2][index1]);
                         if (ret)
                         {
                             continue;
@@ -2479,7 +2479,7 @@ namespace Mids_Reborn.Core
                 var strArray1 = FileIO.IOGrab(streamReader);
                 for (var index = 0; index < 4; ++index)
                 {
-                    var ret = float.TryParse(strArray1[index + 1], out Database.MultTO[0][index]);
+                    var ret = TryParseMathValue(strArray1[index + 1], out Database.MultTO[0][index]);
                     if (ret)
                     {
                         continue;
@@ -2491,7 +2491,7 @@ namespace Mids_Reborn.Core
                 var strArray2 = FileIO.IOGrab(streamReader);
                 for (var index = 0; index < 4; ++index)
                 {
-                    var ret = float.TryParse(strArray2[index + 1], out Database.MultDO[0][index]);
+                    var ret = TryParseMathValue(strArray2[index + 1], out Database.MultDO[0][index]);
                     if (ret)
                     {
                         continue;
@@ -2503,7 +2503,7 @@ namespace Mids_Reborn.Core
                 var strArray3 = FileIO.IOGrab(streamReader);
                 for (var index = 0; index < 4; ++index)
                 {
-                    var ret = float.TryParse(strArray3[index + 1], out Database.MultSO[0][index]);
+                    var ret = TryParseMathValue(strArray3[index + 1], out Database.MultSO[0][index]);
                     if (ret)
                     {
                         continue;
@@ -2515,7 +2515,7 @@ namespace Mids_Reborn.Core
                 var strArray4 = FileIO.IOGrab(streamReader);
                 for (var index = 0; index < 4; ++index)
                 {
-                    var ret = float.TryParse(strArray4[index + 1], out Database.MultHO[0][index]);
+                    var ret = TryParseMathValue(strArray4[index + 1], out Database.MultHO[0][index]);
                     if (ret)
                     {
                         continue;
@@ -2538,7 +2538,7 @@ namespace Mids_Reborn.Core
                     var strArray5 = FileIO.IOGrab(streamReader);
                     for (var index2 = 0; index2 < 4; ++index2)
                     {
-                        var ret = float.TryParse(strArray5[index2 + 1], out Database.MultIO[index1][index2]);
+                        var ret = TryParseMathValue(strArray5[index2 + 1], out Database.MultIO[index1][index2]);
                         if (ret)
                         {
                             continue;
@@ -2583,6 +2583,9 @@ namespace Mids_Reborn.Core
 
             return false;
         }
+
+        private static bool TryParseMathValue(string value, out float result) =>
+            float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
 
         public static void AssignSetBonusIndexes()
         {


### PR DESCRIPTION
Maths.mhd uses a fixed dot decimal separator, but LoadMaths parsed its
floating-point fields using the current culture. On comma-decimal locales,
values such as 0.700 could be interpreted as 700, inflating enhancement and
ED percentages by a factor of 1,000.

Parse only the Maths.mhd numeric fields with NumberStyles.Float and
CultureInfo.InvariantCulture while preserving the existing load-error
behavior.

This issue was discovered while working on Mids Linux.  
I was unable to test the upstream Windows application because I do not have access to a Windows system.